### PR TITLE
fix(uploadController): correct URL path in response data

### DIFF
--- a/dist/controllers/uploadController.js
+++ b/dist/controllers/uploadController.js
@@ -20,7 +20,7 @@ class UploadController {
             });
             console.log("Pronto.io response:", response.data);
             res.status(201).json({
-                url: response.data.url
+                url: response.data.file.url
             });
         }
         catch (error) {

--- a/src/controllers/uploadController.ts
+++ b/src/controllers/uploadController.ts
@@ -30,7 +30,7 @@ class UploadController {
       );
       console.log("Pronto.io response:", response.data);
       res.status(201).json({
-        url: response.data.url
+        url: response.data.file.url
       });
     } catch (error) {
       console.error("Full error:", error);


### PR DESCRIPTION
The response data structure from Pronto.io was updated, requiring the URL path to be adjusted from `response.data.url` to `response.data.file.url` to ensure the correct URL is returned to the client.